### PR TITLE
feature: added applescript for clearing trash

### DIFF
--- a/commands/system/clear-trash.applescript
+++ b/commands/system/clear-trash.applescript
@@ -1,0 +1,28 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Clear Trash
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🤖
+# @raycast.packageName System
+
+# Documentation:
+# @raycast.description Clear Trash
+# @raycast.author chitwan_bindal
+# @raycast.authorURL https://raycast.com/chitwan_bindal
+
+try
+    tell application "Finder"
+        if (count of items in trash) is 0 then
+            log "The trash is already empty."
+        else
+            empty the trash
+            log "Trash has been emptied successfully."
+        end if
+    end tell
+on error errMsg
+    log "An error occurred: " & errMsg
+end try


### PR DESCRIPTION
This applescript is used to clear trash in macOS.

## Description

This **applescript** clear trash in **macOS**. It is a **silent** script of **System** package which logs "The trash is already empty" if there are no items in trash. This check was required because `empty the trash` command throws _"The operation can't be completed."_ error. If any other error was thrown, it is then logged on the user screen. Otherwise, if everything works fine, **"Trash has been emptied successfully**" is logged.

## Type of change

- [x] New script command

## Screenshot

https://github.com/user-attachments/assets/0d803e55-ef3a-4432-a73e-f566c70ed7c2


## Dependencies / Requirements

There is no dependency. Just copy paste and enjoy your saved 5 seconds and 3 extra clicks. 😆

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)